### PR TITLE
Small fixes for elasticsearch service

### DIFF
--- a/2.3/repos/repoinfo.xml
+++ b/2.3/repos/repoinfo.xml
@@ -29,7 +29,7 @@
       <reponame>HDP-UTILS</reponame>
     </repo>
     <repo>
-      <baseurl>https://download.elasticsearch.org/elasticsearch/elasticsearch/</baseurl>
+      <baseurl>http://packages.elastic.co/elasticsearch/1.7/centos</baseurl>
       <repoid>ELASTICSEARCH</repoid>
       <reponame>ELASTICSEARCH</reponame>
     </repo>

--- a/2.3/services/ELASTICSEARCH/package/scripts/service_check.py
+++ b/2.3/services/ELASTICSEARCH/package/scripts/service_check.py
@@ -6,7 +6,7 @@ Elasticsearch service checks.
 from __future__ import print_function
 from resource_management import *
 import  sys,subprocess,os
-import requests
+import urllib2 
 import time
 
 class ServiceCheck(Script):
@@ -15,12 +15,11 @@ class ServiceCheck(Script):
         env.set_params(params)
 
 	print("Running Elastic search  service check", file=sys.stdout)
-        # There is a race condition by the time the BDSE server starts and service checks.  Hence added the below sleep for 20 seconds
-        time.sleep(20)
-    	payload = {'name': 'Buddy.  Dont Worry, I am Fine '} 
-	r = requests.get('http://localhost:9200/',params=payload) 
+        # There is a race condition by the time the BDSE server starts and service checks.  Hence added the below sleep for 30 seconds
+        time.sleep(30)
+	r = urllib2.urlopen('http://localhost:9200/') 
 
-        if r.status_code == 200:
+        if r.getcode() == 200:
 	    print(r.json(), file=sys.stdout)
             sys.exit(0)
         else:


### PR DESCRIPTION
- The default repo location doesn't work. Updated it.
- service_check uses python 'requests' which isn't present on Centos 6, neither was 'pip'. Switched libs.
